### PR TITLE
Ensure that the interface exists before attempting to set it down

### DIFF
--- a/charmhelpers/contrib/network/ovs/__init__.py
+++ b/charmhelpers/contrib/network/ovs/__init__.py
@@ -15,6 +15,7 @@
 ''' Helpers for interacting with OpenvSwitch '''
 import collections
 import hashlib
+import netifaces
 import os
 import re
 import six
@@ -265,7 +266,8 @@ def del_bridge_port(name, port, linkdown=True):
     log('Deleting port {} from bridge {}'.format(port, name))
     subprocess.check_call(["ovs-vsctl", "--", "--if-exists", "del-port",
                            name, port])
-    if linkdown:
+    exists = port in netifaces.interfaces()
+    if linkdown and exists:
         subprocess.check_call(["ip", "link", "set", port, "down"])
         subprocess.check_call(["ip", "link", "set", port, "promisc", "off"])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Jinja2
 
 six
 netaddr
+netifaces
 Tempita
 
 pbr!=2.1.0,>=2.0.0 # Apache-2.0

--- a/tests/contrib/network/ovs/test_ovs.py
+++ b/tests/contrib/network/ovs/test_ovs.py
@@ -130,19 +130,25 @@ class TestOVS(test_utils.BaseTestCase):
     def test_del_bridge_port(self):
         self.patch_object(ovs.subprocess, 'check_call')
         self.patch_object(ovs, 'log')
-        ovs.del_bridge_port('test', 'eth1')
-        self.check_call.assert_has_calls([
-            mock.call(['ovs-vsctl', '--', '--if-exists', 'del-port',
-                       'test', 'eth1']),
-            mock.call(['ip', 'link', 'set', 'eth1', 'down']),
-            mock.call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
-        ])
-        self.assertTrue(self.log.call_count == 1)
-        self.assertTrue(self.check_call.call_count == 3)
-        self.check_call.reset_mock()
-        ovs.del_bridge_port('test', 'eth1', linkdown=False)
+        with mock.patch('netifaces.interfaces', return_value=['eth1']):
+            ovs.del_bridge_port('test', 'eth1')
+            self.check_call.assert_has_calls([
+                mock.call(['ovs-vsctl', '--', '--if-exists', 'del-port', 
+                           'test', 'eth1']),
+                mock.call(['ip', 'link', 'set', 'eth1', 'down']),
+                mock.call(['ip', 'link', 'set', 'eth1', 'promisc', 'off'])
+            ])
+            self.assertTrue(self.log.call_count == 1)
+            self.assertTrue(self.check_call.call_count == 3)
+            self.check_call.reset_mock()
+            ovs.del_bridge_port('test', 'eth1', linkdown=False)
+            self.check_call.assert_called_once_with(
+                ['ovs-vsctl', '--', '--if-exists', 'del-port', 'test', 'eth1'])
+            self.check_call.reset_mock()
+        
+        ovs.del_bridge_port('test', 'fake0')
         self.check_call.assert_called_once_with(
-            ['ovs-vsctl', '--', '--if-exists', 'del-port', 'test', 'eth1'])
+            ['ovs-vsctl', '--', '--if-exists', 'del-port', 'test', 'fake0'])
 
     def test_ovs_appctl(self):
         self.patch_object(ovs.subprocess, 'check_output')


### PR DESCRIPTION
Add a test to see if the interface exists before attempting to set
it down. This will help prevent the hook from ending in error due to a
non-existent interface.

Closes-Bug: #1896913